### PR TITLE
JSXファイルを解決できるようにする

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -141,6 +141,9 @@ const webpackConfig = {
     minimize: !isDev,
     minimizer: [new CssMinimizerPlugin({}), new TerserPlugin({})],
   },
+  resolve: {
+    extensions: [".js", ".jsx"],
+  },
 }
 
 glob


### PR DESCRIPTION
次のようなファイル構成で `pages/index.js` からJSXファイルをimportするとWebpackでエラ―が出ます。
JSXで書きたいこともあるので `webpack.config.js` のオプションに `resolve` を設定しました。

ディレクトリ構成
```
src/
    components/
        Button.jsx
    pages/
        index.js
```

エラー内容
```
ERROR in   Error: Child compilation failed:
  Module not found: Error: Can't resolve '../components/Button' in '/Users/yosukedok  e/Documents/workspaces/test-minista/src/pages'
  ModuleNotFoundError: Module not found: Error: Can't resolve '../components/Button'   in '/Users/yosukedoke/Documents/workspaces/test-minista/src/pages'
```

## テスト結果
テストファイルはコミットしませんでしたが、手元では動作確認しています。

![スクリーンショット 2021-06-17 19 04 28](https://user-images.githubusercontent.com/1049052/122376186-e218f180-cf9e-11eb-920b-d432935a7855.png)
