### PR TITLE
publicPathを指定できるようにする

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,7 @@ const TerserPlugin = require("terser-webpack-plugin")
 const CopyPlugin = require("copy-webpack-plugin")
 
 const isDev = process.env.NODE_ENV !== "production"
+const publicPath = process.env.publicPath || "/"
 
 const webpackConfig = {
   target: "web",
@@ -42,7 +43,7 @@ const webpackConfig = {
   entry: "./src/assets/index.js",
   output: {
     path: path.resolve("dist"),
-    publicPath: "/",
+    publicPath,
     filename: "assets/scripts.js",
   },
   module: {


### PR DESCRIPTION
## 概要

ビルドしたファイルをroot直下ではない GitHub Pages（`https://<USERNAME>.github.io/<REPO>/`）にデプロイする場合、`publicPath`の指定が必要なため、引数を用いて指定できるようにします。

## 利用方法

```json
"scripts": {
  "build": "cross-env publicPath=hoge minista build"
}
```

```
npm run build
```
