### PR TITLE
envによるpublicPathの上書き指定を削除する

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,6 @@ const TerserPlugin = require("terser-webpack-plugin")
 const CopyPlugin = require("copy-webpack-plugin")
 
 const isDev = process.env.NODE_ENV !== "production"
-const publicPath = process.env.publicPath || "/"
 
 const webpackConfig = {
   target: "web",
@@ -43,7 +42,7 @@ const webpackConfig = {
   entry: "./src/assets/index.js",
   output: {
     path: path.resolve("dist"),
-    publicPath,
+    publicPath: "/",
     filename: "assets/scripts.js",
   },
   module: {


### PR DESCRIPTION
## 概要

https://github.com/qrac/minista/pull/2 にて、 `cross-env publicPath=hoge` の指定により webpack.config.js の `output.publicPath` の値を指定するような変更を行っていた。
しかしながら、 https://github.com/qrac/minista/issues/3 によって、webpack.config.js の指定を上書きできるようになり、envによる指定が不要になったため、前述の定義を削除する。

## 利用方法

下記のように publicPath を指定すれば良い。

```js
// webpack.config.js
module.exports = {
  output: {
    publicPath: "/hoge/",
  },
}
```