### PR TITLE
Fix duplicated dots before file extension

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -115,7 +115,7 @@ const webpackConfig = {
     path: path.resolve("dist"),
     publicPath: "/",
     filename: "assets/[name].js",
-    assetModuleFilename: "assets/images/[name].[ext]",
+    assetModuleFilename: "assets/images/[name][ext]",
   },
   module: {
     rules: [
@@ -195,7 +195,7 @@ const webpackConfig = {
         test: /\.(woff2?|eot|ttf|otf)$/i,
         type: "asset/resource",
         generator: {
-          filename: "assets/fonts/[name].[ext]",
+          filename: "assets/fonts/[name][ext]",
         },
       },
       {


### PR DESCRIPTION
webpack の loader を経由した画像等のファイルで、拡張子前のドットが2つ連なってしまうバグを修正しました。
お手数ですがご確認をお願いします！