### PR TITLE
Windows上でのPartialHydrationのパス解決を修正

### DIFF
--- a/src/esbuild.tsx
+++ b/src/esbuild.tsx
@@ -106,9 +106,10 @@ export function partialHydrationPlugin(): Plugin {
     setup(build) {
       build.onResolve({ filter: /\?ph$/ }, (args) => {
         return {
-          path: path.isAbsolute(args.path)
+          path: (path.isAbsolute(args.path)
             ? args.path
-            : path.join(args.resolveDir, args.path),
+            : path.join(args.resolveDir, args.path)
+          ).replaceAll("\\", "/"),
           namespace: "partial-hydration-loader",
         }
       })


### PR DESCRIPTION
Windows上でPartialHydrationを使用するとバックスラッシュが使われてパスがおかしくなりエラーが起きてしまうためスラッシュに置き換える処理を付け足しました。

```ts
import TEST from '../components/test?ph'

export default () => {
  return (
    <div>
      <TEST />
    </div>
  )
}

```

```bash
X [ERROR] Could not resolve "C:projectsrccomponents\test"

    node_modules/.minista/partial-hydration/string-index.mjs:2:17:
      2 │ import PH_1 from "E:\project\src\components\test"
        ╵                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  You can mark the path "C:projectsrccomponents\test" as external
  to exclude it from the bundle, which will remove this error.
```
