### PR TITLE
css modulesに対応

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,8 +67,11 @@
     "semi": false
   },
   "peerDependencies": {
+    "less": "^4.1.2",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react-dom": "^17.0.2",
+    "sass": "^1.51.0",
+    "stylus": "^0.57.0"
   },
   "dependencies": {
     "@mdx-js/esbuild": "^2.1.1",
@@ -84,6 +87,8 @@
     "node-fetch": "^3.2.4",
     "node-html-parser": "^5.3.3",
     "picocolors": "^1.0.0",
+    "postcss": "^8.4.13",
+    "postcss-modules": "^4.3.1",
     "react-helmet": "^6.1.0",
     "react-router-dom": "^6.3.0",
     "rehype-highlight": "^5.0.2",
@@ -99,14 +104,19 @@
   "devDependencies": {
     "@types/fs-extra": "^9.0.13",
     "@types/js-beautify": "^1.13.3",
+    "@types/less": "^3.0.3",
     "@types/mime-types": "^2.1.1",
     "@types/node": "^17.0.31",
     "@types/react": "^17.0.45",
     "@types/react-dom": "^17.0.16",
     "@types/react-helmet": "^6.1.5",
+    "@types/stylus": "^0.48.38",
     "@types/uuid": "^8.3.4",
+    "less": "^4.1.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "sass": "^1.51.0",
+    "stylus": "^0.57.0",
     "tsup": "^5.12.7",
     "typescript": "^4.6.4",
     "vitest": "^0.12.0"

--- a/src/build.tsx
+++ b/src/build.tsx
@@ -31,6 +31,7 @@ import type {
   GetStaticData,
   PartialModules,
   PartialString,
+  CssOptions,
 } from "./types.js"
 
 import { systemConfig } from "./system.js"
@@ -43,6 +44,7 @@ import {
 } from "./esbuild.js"
 import { renderHtml } from "./render.js"
 import { slashEnd, reactStylesToString } from "./utils.js"
+import { CssModulePlugin } from "./css.js"
 
 const __filename = url.fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -94,6 +96,7 @@ export async function buildTempPages(
     outDir: string
     mdxConfig: MdxOptions
     svgrOptions: SvgrOptions
+    cssOptions: CssOptions
   }
 ) {
   await esBuild({
@@ -111,6 +114,7 @@ export async function buildTempPages(
     external: esbuildExternals,
     loader: esbuildLoaders,
     plugins: [
+      CssModulePlugin(buildOptions.cssOptions),
       mdx(buildOptions.mdxConfig),
       resolvePlugin({
         "react/jsx-runtime": "react/jsx-runtime.js",
@@ -631,6 +635,7 @@ export async function buildPartialStringBundle(
     outFile: string
     mdxConfig: MdxOptions
     svgrOptions: SvgrOptions
+    cssOptions: CssOptions
   }
 ) {
   await esBuild({
@@ -646,6 +651,7 @@ export async function buildPartialStringBundle(
     external: esbuildExternals,
     loader: esbuildLoaders,
     plugins: [
+      CssModulePlugin(buildOptions.cssOptions),
       mdx(buildOptions.mdxConfig),
       resolvePlugin({
         "react/jsx-runtime": "react/jsx-runtime.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -92,6 +92,21 @@ export const defaultConfig: MinistaConfig = {
     cssOptions: {},
     jsOptions: {},
   },
+  css: {
+    modules: {
+      generateScopedName: undefined,
+      globalModulePaths: [],
+      hashPrefix: "",
+      localsConvention: "camelCaseOnly",
+      scopeBehaviour: "local",
+      cache: true,
+    },
+    preprocessorOptions: {
+      scss: {},
+      less: {},
+      stylus: {},
+    },
+  },
 }
 
 export async function mergeConfig(

--- a/src/css.ts
+++ b/src/css.ts
@@ -1,0 +1,183 @@
+import path from "path"
+import fs from "fs-extra"
+
+import postcss from "postcss"
+import postcssModules from "postcss-modules"
+
+import type { Plugin } from "esbuild"
+import type Less from "less"
+import type Sass from "sass"
+import type Stylus from "stylus"
+
+import type { CssOptions } from "./types.js"
+
+enum PreprocessLang {
+  less = "less",
+  sass = "sass",
+  scss = "scss",
+  styl = "styl",
+  stylus = "stylus",
+}
+type CssLang = "css" | keyof typeof PreprocessLang
+type PreprocessorTypes = {
+  [PreprocessLang.less]: typeof Less
+  [PreprocessLang.sass]: typeof Sass
+  [PreprocessLang.scss]: typeof Sass
+  [PreprocessLang.styl]: typeof Stylus
+  [PreprocessLang.stylus]: typeof Stylus
+}
+type StylePreprocessor = (
+  cssFullPath: string,
+  options: CssOptions
+) => Promise<string>
+
+const PLUGIN = "esbuild-cssmodule-plugin"
+const cssLangs = `\\.(css|less|sass|scss|styl|stylus)($|\\?)`
+const cssLangRE = new RegExp(cssLangs)
+
+async function loadPreprocessor<L extends PreprocessLang>(
+  lang: L
+): Promise<PreprocessorTypes[L]> {
+  try {
+    const preprocessor = await import(lang)
+    return preprocessor.default
+  } catch (e: any) {
+    if (e.code === "ERR_MODULE_NOT_FOUND") {
+      throw new Error(
+        `Preprocessor dependency "${lang}" not found. Did you install it?`
+      )
+    } else {
+      const error = new Error(
+        `Preprocessor dependency "${lang}" failed to load:\n${e.message}`
+      )
+      error.stack = `${e.stack}\n${error.stack}`
+      throw error
+    }
+  }
+}
+
+// .less
+const less: StylePreprocessor = async (
+  filepath: string,
+  options: CssOptions
+) => {
+  const less = await loadPreprocessor(PreprocessLang.less)
+  const content = await fs.readFile(filepath, "utf8")
+  less.render("", {})
+  const result = await less.render(content, {
+    ...options.preprocessorOptions.less,
+  })
+  return result.css
+}
+
+// .scss / .sass
+const scss: StylePreprocessor = async (
+  scssFullPath: string,
+  options: CssOptions
+) => {
+  const sass = await loadPreprocessor(PreprocessLang.sass)
+  const result = await sass.compileAsync(scssFullPath, {
+    ...options.preprocessorOptions.scss,
+  })
+  return result.css
+}
+
+// .styl / .stylus
+const stylus: StylePreprocessor = async (
+  filepath: string,
+  options: CssOptions
+) => {
+  const stylus = await loadPreprocessor(PreprocessLang.stylus)
+  const content = await fs.readFile(filepath, "utf8")
+  const result = stylus(content, {
+    ...options.preprocessorOptions.stylus,
+  })
+    .set("filename", filepath)
+    .render()
+  return result
+}
+
+const preProcessors = {
+  [PreprocessLang.less]: less,
+  [PreprocessLang.sass]: scss,
+  [PreprocessLang.scss]: scss,
+  [PreprocessLang.styl]: stylus,
+  [PreprocessLang.stylus]: stylus,
+}
+
+async function buildCss(filepath: string, options: CssOptions) {
+  const lang = filepath.match(cssLangRE)?.[1] as CssLang
+  let css: string | undefined = undefined
+
+  if (lang !== "css") {
+    const preProcessor = preProcessors[lang]
+    if (preProcessor) {
+      css = await preProcessor(filepath, options)
+    } else {
+      console.warn(`${PLUGIN}: Unsupported CSS language: ${lang}`)
+      return
+    }
+  } else {
+    css = await fs.readFile(filepath, "utf8")
+  }
+  return css
+}
+
+async function buildJs(filepath: string, options: CssOptions) {
+  const css = await buildCss(filepath, options)
+
+  if (!css) return
+
+  let cssModulesJSON = {}
+  await postcss([
+    postcssModules({
+      ...options.modules,
+      getJSON(_, json) {
+        cssModulesJSON = json
+        return cssModulesJSON
+      },
+    }),
+  ]).process(css, {
+    from: filepath,
+    map: false,
+  })
+
+  const classNames = JSON.stringify(cssModulesJSON)
+
+  return `export default ${classNames};`
+}
+
+export function CssModulePlugin(options: CssOptions): Plugin {
+  const filter = new RegExp(`\\.module${cssLangs}`)
+  return {
+    name: PLUGIN,
+    setup(build) {
+      const results = new Map()
+      build.onResolve({ filter, namespace: "file" }, async (args) => {
+        if (!options.modules) return args
+        const sourceFullPath = path.resolve(args.resolveDir, args.path)
+        if (results.has(sourceFullPath)) return results.get(sourceFullPath)
+
+        const content = await buildJs(sourceFullPath, options)
+        const result = {
+          path: args.path,
+          namespace: PLUGIN,
+          pluginData: {
+            content,
+          },
+        }
+
+        if (options.modules.cache) results.set(sourceFullPath, result)
+        return result
+      })
+
+      build.onLoad({ filter, namespace: PLUGIN }, (args) => {
+        if (!args.pluginData.content) return args
+        return {
+          contents: args.pluginData.content,
+          loader: "js",
+        }
+      })
+    },
+  }
+}

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -71,6 +71,7 @@ export async function generateTempRoot(
       outDir: systemConfig.temp.root.outDir,
       mdxConfig: mdxConfig,
       svgrOptions: config.assets.svgr.svgrOptions,
+      cssOptions: config.css,
     })
   }
 }
@@ -88,6 +89,7 @@ export async function generateTempPages(
     outDir: systemConfig.temp.pages.outDir,
     mdxConfig: mdxConfig,
     svgrOptions: config.assets.svgr.svgrOptions,
+    cssOptions: config.css,
   })
 }
 
@@ -141,6 +143,7 @@ export async function generatePartialHydration(
     outFile: stringBundle,
     mdxConfig: mdxConfig,
     svgrOptions: config.assets.svgr.svgrOptions,
+    cssOptions: config.css
   })
   await optimizeCommentOutStyleImport([stringBundle])
   await buildPartialStringInitial(stringBundle, partialModules, {

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,9 @@ import type {
   JSBeautifyOptions,
 } from "js-beautify"
 
+import type Sass from "sass"
+import type Stylus from "stylus"
+
 export type MinistaConfig = {
   base: string
   public: string
@@ -84,6 +87,7 @@ export type MinistaConfig = {
     cssOptions: CSSBeautifyOptions
     jsOptions: JSBeautifyOptions
   }
+  css: CssOptions
 }
 
 export type MinistaUserConfig = {
@@ -158,6 +162,7 @@ export type MinistaUserConfig = {
     cssOptions?: CSSBeautifyOptions
     jsOptions?: JSBeautifyOptions
   }
+  css?: CssUserOptions
 }
 
 export type MinistaSvgstoreOptions = {
@@ -280,4 +285,32 @@ export type PartialModules = {
 }[]
 export type PartialString = {
   [key: string]: string
+}
+
+export type CSSModulesOptions = {
+  cache: boolean
+  scopeBehaviour: "global" | "local"
+  globalModulePaths: RegExp[]
+  generateScopedName:
+    | undefined
+    | string
+    | ((name: string, filename: string, css: string) => string)
+  hashPrefix: string
+  localsConvention: "camelCase" | "camelCaseOnly" | "dashes" | "dashesOnly"
+}
+export type CssOptions = {
+  modules: CSSModulesOptions | false
+  preprocessorOptions: {
+    scss: Sass.Options<"async">
+    less: Less.Options
+    stylus: Stylus.RenderOptions
+  }
+}
+export type CssUserOptions = {
+  modules?: Partial<CSSModulesOptions> | false
+  preprocessorOptions?: {
+    scss?: Sass.Options<"async">
+    less?: Less.Options
+    stylus?: Stylus.RenderOptions
+  }
 }

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -115,6 +115,7 @@ export async function getViteConfig(
       ],
     },
     customLogger: createLogger("info", { prefix: "[minista]" }),
+    css: config.css,
   })
 
   const mergedViteConfig = mergeViteConfig(defaultViteConfig, config.vite)


### PR DESCRIPTION
度々のPR失礼します；
css modulesに対応させました。
viteの方は標準で対応していたので、esbuildの方にcssmodulesのクラス名を適応させるプラグインを実装しました。また、一部設定の共通化を行っています。