### PR TITLE
Node.jsでnpm run playなどが実行不能だったので修正

### DIFF
--- a/packages/plugin-ssg/package.json
+++ b/packages/plugin-ssg/package.json
@@ -53,7 +53,7 @@
   },
   "scripts": {
     "build": "npm run clean && npm run build-src && npm run build-type",
-    "build-src": "esbuild ./src/client/*.ts ./src/node/*.{ts,tsx} --outbase=src --outdir=dist",
+    "build-src": "esbuild ./src/client/*.ts ./src/node/*.ts ./src/node/*.tsx --outbase=src --outdir=dist",
     "build-type": "tsc",
     "clean": "rimraf ./dist",
     "prepublishOnly": "npm run build"

--- a/packages/plugin-story/package.json
+++ b/packages/plugin-story/package.json
@@ -54,7 +54,7 @@
   },
   "scripts": {
     "build": "npm run clean && npm run build-src && npm run build-type",
-    "build-src": "esbuild ./src/client/*.{ts,tsx} ./src/client/**/*.{tsx,css} ./src/node/*.{ts,tsx} ./src/assets/*.css ./src/assets/**/*.css --outbase=src --outdir=dist",
+    "build-src": "esbuild ./src/client/*.ts ./src/client/*.tsx ./src/client/**/*.tsx ./src/client/**/*.css ./src/node/*.ts ./src/node/*.tsx ./src/assets/*.css ./src/assets/**/*.css --outbase=src --outdir=dist",
     "build-type": "tsc",
     "clean": "rimraf ./dist",
     "prepublishOnly": "npm run build"

--- a/packages/shared-head/package.json
+++ b/packages/shared-head/package.json
@@ -57,7 +57,7 @@
   },
   "scripts": {
     "build": "npm run clean && npm run build-src && npm run build-type",
-    "build-src": "esbuild ./src/client/*.ts ./src/node/*.{ts,tsx} ./src/shared/*.ts --outbase=src --outdir=dist",
+    "build-src": "esbuild ./src/client/*.ts ./src/node/*.ts ./src/node/*.tsx ./src/shared/*.ts --outbase=src --outdir=dist",
     "build-type": "tsc",
     "clean": "rimraf ./dist",
     "prepublishOnly": "npm run build"


### PR DESCRIPTION
# 修正箇所

esbuildのエントリーポイントで、`{ts,tsx}`のようなファイルパターンを使っている箇所を展開する形に置換しました。

# 対応した理由

`npm run build`後に、`npm run play`などが動きませんでした。

```bash
$ npm run play

> minista-monorepo@4.0.0-alpha.8 play
> npx minista ./playground/_default

✘ [ERROR] Failed to resolve entry for package "minista-plugin-ssg". The package may have incorrect main/module/exports specified in its package.json. [plugin externalize-deps]

    node_modules/vite/node_modules/esbuild/lib/main.js:1225:27:
      1225 │         let result = await callback({
```

## 原因

原因を調査したところ、build時に一部のファイルが出力されていない事が分かりました。
出力されていないファイルの傾向を確認すると、esbuildで以下の書き方がされている箇所でした。

```
*.{ts,tsx}
```

esbuildのCLIについて調査をしたところ、このようなパターンはサポートされていないようでした。
https://esbuild.github.io/api/#glob-style-entry-points

よって、展開する形に置換しました。

```
*.ts *.tsx
```

以上の修正を加えることにより、`npm run play`が動くようになりました。

## 環境

- Ubuntu 22.04.2 LTS (on WSL2/Win11)
- Node.js v22.5.1